### PR TITLE
fix: Turns off fileglancer-central domain.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,36 +11,6 @@ server {
   return 301 https://$host$request_uri;
 }
 
-
-# fileglancer central server is served on a different domain to prevent
-# clashes in urls
-server {
-  listen 443 ssl;
-  server_name fileglancer-central.int.janelia.org fileglancer-central-dev.int.janelia.org;
-  client_body_buffer_size 50M;
-  client_max_body_size 512M;
-
-  # from https://medium.com/@mvuksano/how-to-properly-configure-your-nginx-for-tls-564651438fe0
-  ssl_certificate           /etc/nginx/certs/default.crt;
-  ssl_certificate_key       /etc/nginx/certs/default.key;
-  ssl_session_cache         shared:SSL:40m;
-  ssl_session_timeout       4h;
-  ssl_protocols             TLSv1.2 TLSv1.3;
-  ssl_ciphers               ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
-  ssl_prefer_server_ciphers on;
-
-  location / {
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_redirect off;
-    proxy_buffering off;
-    proxy_pass http://127.0.0.1:8989;
-  }
-}
-
 server {
   listen       443 ssl default_server http2;
   server_name  fileglancer.int.janelia.org fileglancer-dev.int.janelia.org;
@@ -49,6 +19,16 @@ server {
   ssl_certificate_key       /etc/nginx/certs/default.key;
 
   root  /etc/nginx/html;
+
+  # pass all requests to /fc/files to the fileglancer central server.
+  location /fc/files/ {
+    rewrite ^/fc/files/(.*)$ /files/$1 break;
+    proxy_pass http://127.0.0.1:8989;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
 
   location / {
     proxy_pass http://127.0.0.1:8000;


### PR DESCRIPTION
This domain was being used to expose the fileglancer-central service,
but we really don't want to do that as it has endpoints that can be
destructive. This also updates the nginx proxy to serve files from the
fileglancer central server via the /fc/files url.

@krokicki 