### PR TITLE
fix: Adds /fg/assets/ to nginx.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,23 @@ sudo systemctl start fileglancer-hub
 ```bash
 yum install nginx
 ```
-2. copy the nginx configuration file to `/etc/nginx/conf.d/fileglancer.conf`
+2. set up the static path for the fileglancer assets
+```bash
+find /opt/deploy/fileglancer-hub/ -name "assets"
+```
+Use this path to replace the `<path_to_fileglancer_assets>` placeholder of the nginx configuration file `nginx.conf` in this repository.
+
+3. copy the nginx configuration file to `/etc/nginx/conf.d/fileglancer.conf`
 ```bash
 sudo cp nginx.conf /etc/nginx/conf.d/fileglancer.conf
 ```
-3. disable the default server block
+4. disable the default server block
 - comment out the default server block `server {}`
 ```bash
 sudo nano /etc/nginx/nginx.conf
 ```
 
-4. obtain the SSL certificate for *.int.janelia.org and install it in `/etc/nginx/certs/`
+5. obtain the SSL certificate for *.int.janelia.org and install it in `/etc/nginx/certs/`
 ```bash
 sudo mkdir -p /etc/nginx/certs/
 sudo cp cert.pem /etc/nginx/certs/default.crt
@@ -98,11 +104,11 @@ sudo chmod 644 /etc/nginx/certs/default.crt
 sudo chmod 600 /etc/nginx/certs/default.key
 ```
 
-5. enable the service
+6. enable the service
 ```bash
 sudo systemctl enable nginx
 ```
-6. start the service
+7. start the service
 ```bash
 sudo systemctl start nginx
 ```

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,6 +30,20 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  # pass all requests to /fg/assets to the fileglancer assets files. This bypasses
+  # the jupyter servers and serves the assets directly from the file system. It makes
+  # it easier to find the assets and also reduces the load on the jupyter servers.
+
+  location /fg/assets/ {
+    alias <path_to_fileglancer_assets>;
+    # e.g. alias /opt/deploy/fileglancer-hub/.pixi/envs/hub/lib/python3.13/site-packages/fileglancer/ui/assets/;
+    # to locate this path, run:
+    #  find /opt/deploy/fileglancer-hub/ -name "assets"
+    autoindex off;
+    expires max;
+  }
+
+
   location / {
     proxy_pass http://127.0.0.1:8000;
 


### PR DESCRIPTION
This adds a /fg/assets/ location to the nginx server, so that we can
serve the fileglancer static assets from a reliable location. Before
this change, the assets were being referenced via a relative url, eg
"./assets/index.js". This worked as long as we didn't have a url of more
than one level deep. For example, urls like /fg/browse and /fg/help worked,
but if we needed to have a url like /fg/browse/file/data, the assets
request url would be /fg/browse/file/assets, instead of /fg/assets.
Typically this could be fixed by setting a base in the vite config file,
but we have the added complexity that we are using jupyterhub as a
reverse proxy, with the user name in the url, so we need to serve the
site from /user/<username>/fg. This would be different everytime, so the
base could not be added to the index.html file at build time. Since we
are using nginx in front of the jupyterhub server, we can grab the
requests for /fg/assets and serve those requests directly from the
filesystem. This also saves us from using jupyterhub to serve up static
assets.
