### PR TITLE
feat: Adds maintenance mode to the nginx server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,39 @@ sudo journalctl -u fileglancer-central -f
 sudo journalctl -u fileglancer-hub -f
 sudo journalctl -u nginx -f
 ```
+
+### Maintenance Mode
+
+The nginx configuration includes maintenance mode functionality that will display a maintenance page when needed.
+
+#### Enabling Maintenance Mode
+
+1. Copy the example maintenance page to the nginx html directory:
+```bash
+sudo cp maintenance.html.example /etc/nginx/html/maintenance.html
+```
+
+2. Edit the maintenance page to update the estimated completion time:
+```bash
+sudo nano /etc/nginx/html/maintenance.html
+```
+Replace `[UPDATE WITH ACTUAL TIME]` with the actual estimated completion time.
+
+3. Reload nginx to activate maintenance mode:
+```bash
+sudo systemctl reload nginx
+```
+
+#### Disabling Maintenance Mode
+
+1. Remove the maintenance page:
+```bash
+sudo rm /etc/nginx/html/maintenance.html
+```
+
+2. Reload nginx:
+```bash
+sudo systemctl reload nginx
+```
+
+**Note:** When maintenance mode is active, all requests to the main site and `/fc/files/` endpoints will show the maintenance page instead of the normal application. Static assets like `/fg/assets/` and `/fg/logo.svg` will continue to work normally to ensure the maintenance page displays correctly.

--- a/maintenance.html.example
+++ b/maintenance.html.example
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FileGlancer - Maintenance</title>
+    <link rel="icon" href="./logo.svg" type="image/x-icon">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: radial-gradient(ellipse at center, #334155 0%, #1e293b 100%);
+            color: white;
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            text-align: center;
+            max-width: 600px;
+            padding: 2rem;
+        }
+        .icon {
+            font-size: 4rem;
+            margin-bottom: 1rem;
+        }
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            font-weight: 300;
+        }
+        p {
+            font-size: 1.2rem;
+            line-height: 1.6;
+            margin-bottom: 2rem;
+            opacity: 0.9;
+        }
+        .eta {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 8px;
+            padding: 1rem;
+            margin-top: 2rem;
+        }
+        .contact {
+            margin-top: 2rem;
+            font-size: 0.9rem;
+            opacity: 0.8;
+        }
+        .contact a {
+            color: #36a9b0;
+            text-decoration: none;
+        }
+        .contact a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <svg width="80" height="107" viewBox="0 0 101.6 135.467" style="margin-bottom: 1rem;">
+            <defs>
+                <linearGradient id="fileglancerGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                    <stop offset="0%" style="stop-color:#8b5cf6;stop-opacity:1;" />
+                    <stop offset="100%" style="stop-color:#36a9b0;stop-opacity:1;" />
+                </linearGradient>
+                <mask id="eyeMask">
+                    <rect width="100%" height="100%" fill="white" />
+                    <path d="M 16 86.89 Q 51.5 97 87 86.89" stroke="black" stroke-width="6" stroke-linecap="round" fill="none" />
+                    <line x1="28" y1="91" x2="24" y2="99" stroke="black" stroke-width="3" stroke-linecap="round" />
+                    <line x1="41" y1="93" x2="38" y2="101" stroke="black" stroke-width="3" stroke-linecap="round" />
+                    <line x1="51.5" y1="95" x2="51.5" y2="103" stroke="black" stroke-width="3" stroke-linecap="round" />
+                    <line x1="62" y1="93" x2="65" y2="101" stroke="black" stroke-width="3" stroke-linecap="round" />
+                    <line x1="75" y1="91" x2="79" y2="99" stroke="black" stroke-width="3" stroke-linecap="round" />
+                </mask>
+            </defs>
+            <path d="m 51.49573,58.872514 c -10.1069,0 -18.199926,4.60314 -24.091449,10.08188 -5.853997,5.42871 -9.76917,11.93315 -11.620434,16.39869 -0.412782,0.98818 -0.412782,2.08893 0,3.07711 1.851264,4.46555 5.766437,10.96999 11.620434,16.398686 5.891523,5.47875 13.984549,10.08189 24.091449,10.08189 10.1069,0 18.19992,-4.60314 24.09145,-10.08189 5.854,-5.441206 9.76917,-11.933136 11.63295,-16.398686 0.41277,-0.98818 0.41277,-2.08893 0,-3.07711 -1.86378,-4.46554 -5.77895,-10.96998 -11.63295,-16.39869 -5.89153,-5.47874 -13.98455,-10.08188 -24.09145,-10.08188 z" fill="url(#fileglancerGradient)" mask="url(#eyeMask)" />
+            <path d="M 93.13334,118.53332 V 50.799994 H 63.5 c -7.01145,0 -12.7,-5.68854 -12.7,-12.7 V 8.466657 H 16.933338 c -4.68313,0 -8.46667,3.783541 -8.46667,8.466665 V 118.53332 c 0,4.68313 3.78354,8.46667 8.46667,8.46667 H 84.66667 c 4.68313,0 8.46667,-3.78354 8.46667,-8.46667 z M 93.00105,42.333324 c -0.18521,-0.74083 -0.55563,-1.42875 -1.11125,-1.95791 L 61.22459,9.710199 C 60.66896,9.154574 60.0075,8.784157 59.26667,8.598949 v 29.501045 c 0,2.32833 1.905,4.23333 4.23333,4.23333 z M -2e-6,16.933322 C -2e-6,7.593532 7.593538,-10e-6 16.933338,-10e-6 H 58.2348 c 3.3602,0 6.58812,1.349375 8.96937,3.730625 l 30.66521,30.638749 c 2.38124,2.38125 3.73062,5.60917 3.73062,8.96938 v 75.194576 c 0,9.33979 -7.59354,16.93334 -16.93333,16.93334 H 16.933338 c -9.3398,0 -16.93334,-7.59355 -16.93334,-16.93334 z" fill="url(#fileglancerGradient)" />
+        </svg>
+        <h1>Scheduled Maintenance</h1>
+
+        <div class="eta">
+            <strong>Estimated completion:</strong> [UPDATE WITH ACTUAL TIME]
+        </div>
+
+        <p>
+            FileGlancer is currently undergoing scheduled maintenance to improve performance and add new features.
+        </p>
+        <p>
+            We apologize for any inconvenience and appreciate your patience.
+        </p>
+
+        <div class="contact">
+            For urgent matters, please contact <a href="mailto:support@hhmi.org">support</a>.
+        </div>
+    </div>
+</body>
+</html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,8 +20,36 @@ server {
 
   root  /etc/nginx/html;
 
+  # Check for maintenance mode - if maintenance.html exists in the server root
+  # directory (e.g. /etc/nginx/html), serve it for all requests.
+  location / {
+    try_files /maintenance.html @normal;
+  }
+
+  location @normal {
+    try_files $uri @proxy;
+  }
+
+  location @proxy {
+    proxy_pass http://127.0.0.1:8000;
+
+    proxy_redirect   off;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # websocket headers
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+
   # pass all requests to /fc/files to the fileglancer central server.
   location /fc/files/ {
+    try_files /maintenance.html @fc_files;
+  }
+
+  location @fc_files {
     rewrite ^/fc/files/(.*)$ /files/$1 break;
     proxy_pass http://127.0.0.1:8989;
     proxy_set_header Host $host;
@@ -55,19 +83,6 @@ server {
   }
 
 
-  location / {
-    proxy_pass http://127.0.0.1:8000;
-
-    proxy_redirect   off;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    # websocket headers
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-  }
 
   error_page 404 /404.html;
     location = /40x.html {


### PR DESCRIPTION
Click up: [86abwkmf7](https://app.clickup.com/t/86abwkmf7)

- Configures nginx to serve maintenance.html when present for main site and /fc/files/ endpoints
- Adds maintenance.html.example template with FileGlancer branding and closed-eye logo
- Updates README.md with detailed maintenance mode setup and usage instructions

Adding a maintenance.html file to the server root will cause it to enter
"maintenance" mode. With this in place the server will stop serving up
anything from the reverse proxies and will only show the maintenance
message.

@krokicki 