### PR TITLE
docs: add instructions for dev playwright tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Scripts and configuration files for deploying Fileglancer in production at Janel
 This assumes you have a working [Pixi](https://pixi.sh) installation.
 
 1. Clone this repository
+
 ```bash
 git clone git@github.com:JaneliaSciComp/fileglancer-hub.git
 cd fileglancer-hub
 ```
 
 2. Start the Fileglancer server
+
 ```bash
 pixi run start
 ```
@@ -20,33 +22,40 @@ pixi run start
 ## Production Deployment
 
 When working with a shared server, make sure to set your umask so that everything is writeable by the group:
+
 ```bash
 umask 002
 ```
 
 ### Fileglancer Installation
 
-In production the servers need to run as root in order to allow for setuid priviledge. 
+In production the servers need to run as root in order to allow for setuid priviledge.
 
 1. Download and install Pixi into `/usr/local/bin`
+
 ```bash
 curl -fsSL https://pixi.sh/install.sh | sh
 sudo cp $HOME/.pixi/bin/pixi /usr/local/bin/
 ```
 
 2. Create the working directories
+
 ```bash
 sudo install -d -m 2775 -o $USER -g $(id -gn) /opt/deploy /opt/data
 mkdir -p /opt/deploy/fileglancer-hub
 mkdir -p /opt/data/fileglancer # optional, if you want to use a sqlite database
 ```
+
 3. Clone the repository into `/opt/deploy/fileglancer-hub`
+
 ```bash
 cd /opt/deploy/
 git clone git@github.com:JaneliaSciComp/fileglancer-hub.git
 cd fileglancer-hub
 ```
+
 4. Create a file at `/opt/deploy/fileglancer-hub/.env` with the following content (modify the `FGC_EXTERNAL_PROXY_URL` to use the server hostname):
+
 ```bash
 FGC_EXTERNAL_PROXY_URL=https://fileglancer-dev.int.janelia.org/files
 
@@ -70,47 +79,61 @@ FGC_OAUTH_CALLBACK_DOMAIN=<the domain of the hub, e.g. fileglancer.int.janelia.o
 ```
 
 6. Install the systemd service files
+
 ```bash
 sudo cp fileglancer.service /etc/systemd/system/fileglancer.service
 ```
+
 7. Enable the services
+
 ```bash
 sudo systemctl enable fileglancer
 ```
+
 8. Start the service
+
 ```bash
 sudo systemctl start fileglancer
 ```
 
 ### NGINX Reverse Proxy Installation
+
 1. Install nginx
+
 ```bash
 sudo yum install nginx
 ```
 
 2. Copy the nginx configuration file to `/etc/nginx/conf.d/fileglancer.conf`
+
 ```bash
 sudo cp nginx.conf /etc/nginx/conf.d/fileglancer.conf
 ```
 
 3. Set up the static path for the Fileglancer assets
+
 ```bash
 find /opt/deploy/fileglancer-hub/ -name "assets"
 ```
+
 Use this path to replace the `<path_to_fileglancer_assets>` placeholder in the Nginx configuration file (`/etc/nginx/conf.d/fileglancer.conf`).
 
 ```bash
 find /opt/deploy/fileglancer-hub/ -name "ui"
 ```
+
 Use this path to replace the `<path_to_fileglancer_ui_directory>` placeholder in the Nginx configuration file (`/etc/nginx/conf.d/fileglancer.conf`).
 
 4. Disable the default server block
+
 - comment out the default server block in the main Nginx configuration file
+
 ```bash
 sudo nano /etc/nginx/nginx.conf
 ```
 
-5. Obtain the SSL certificate for *.int.janelia.org and install it in `/etc/nginx/certs/`
+5. Obtain the SSL certificate for \*.int.janelia.org and install it in `/etc/nginx/certs/`
+
 ```bash
 sudo mkdir -p /etc/nginx/certs/
 sudo cp cert.pem /etc/nginx/certs/default.crt
@@ -118,6 +141,7 @@ sudo cp key.pem /etc/nginx/certs/default.key
 ```
 
 - Make sure the permissions are correct
+
 ```bash
 sudo chown root:root /etc/nginx/certs/default.crt
 sudo chown root:root /etc/nginx/certs/default.key
@@ -126,11 +150,13 @@ sudo chmod 600 /etc/nginx/certs/default.key
 ```
 
 6. Enable the service
+
 ```bash
 sudo systemctl enable nginx
 ```
 
 7. Start the service
+
 ```bash
 sudo systemctl start nginx
 ```
@@ -140,19 +166,20 @@ sudo systemctl start nginx
 ### Updating to a new version
 
 First, update to the version of Fileglancer you want to deploy:
+
 ```bash
 cd /opt/deploy/fileglancer-hub
 git pull
 ```
 
 Then restart the services:
+
 ```bash
 sudo systemctl restart fileglancer
 sudo systemctl restart nginx
 ```
 
 Make sure to check the logs and smoketest the service to ensure everything came up correctly.
-
 
 ### Hub status checks
 
@@ -175,17 +202,21 @@ The nginx configuration includes maintenance mode functionality that will displa
 #### Enabling Maintenance Mode
 
 1. Copy the example maintenance page to the nginx html directory:
+
 ```bash
 sudo cp maintenance.html.example /etc/nginx/html/maintenance.html
 ```
 
 2. If desired, edit the maintenance page to uncomment the estimated completion time section:
+
 ```bash
 sudo nano /etc/nginx/html/maintenance.html
 ```
+
 Replace `[UPDATE WITH ACTUAL TIME]` with the actual estimated completion time.
 
 3. Reload nginx to activate maintenance mode:
+
 ```bash
 sudo systemctl reload nginx
 ```
@@ -193,11 +224,13 @@ sudo systemctl reload nginx
 #### Disabling Maintenance Mode
 
 1. Remove the maintenance page:
+
 ```bash
 sudo rm /etc/nginx/html/maintenance.html
 ```
 
 2. Reload nginx:
+
 ```bash
 sudo systemctl reload nginx
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,10 @@
 # Releasing Fileglancer
 
-## Release Fileglancer to PyPI
+## 1. Make a new pre-release to PyPI
 
-Follow the Fileglancer [release steps](https://github.com/JaneliaSciComp/fileglancer/blob/main/docs/Release.md) to push a new version of `fileglancer` to [PyPI](https://pypi.org/project/fileglancer/).
+Push a new alpha version of `fileglancer` to [PyPI](https://pypi.org/project/fileglancer/), following the Fileglancer [release steps](https://github.com/JaneliaSciComp/fileglancer/blob/main/docs/Release.md).
 
-## Update versions in Fileglancer Hub
+## 2. Update versions in Fileglancer Hub
 
 Update the version in `pixi.toml` (in this repo) to point to the latest version of `fileglancer`.
 
@@ -28,7 +28,7 @@ If this command fails to clear the cache, manually clear it using the directory 
 rm -r <path/to/.cache/rattler/cache/uv-cache>
 ```
 
-## Dev Deployment
+## 3. Alpha version (dev) deployment
 
 SSH to the Fileglancer development server and update the fileglancer-hub code:
 
@@ -37,7 +37,7 @@ cd /opt/deploy/fileglancer-hub
 git pull
 ```
 
-Announce a deployment in progress in the #fileglancer-support channel on Slack, and stop the services:
+Stop the services:
 
 ```
 sudo systemctl stop fileglancer
@@ -50,8 +50,27 @@ sudo systemctl start fileglancer
 sudo journalctl -u fileglancer -f
 ```
 
-Smoke test the installation to make sure everything is working as expected.
+## 4. Run integration tests against the dev deployment
 
-## Prod Deployment
+To test the full application stack prior to a production release, ensure `.env` file in this repo contains the following:
 
-Repeat the above instructions on the production server.
+```
+FGC_ENABLE_TEST_API_KEY=true
+FGC_TEST_API_KEY:'<your-generated-key>'
+```
+
+If a FGC_TEST_API_KEY is not already configured, create a new one. Add this key to both the `.env` file for fileglancer-hub and fileglancer-janelia/playwright.
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+The same value for `FGC_TEST_API_KEY` needs to be added to the `.env` file in the repo with your Playwright tests. See the [fileglancer-janelia](https://github.com/JaneliaSciComp/fileglancer-janelia) repo for example Playwright tests and further documentation of this feature.
+
+## 5. Make a new stable release to PyPI
+
+Push a new major, minor, or patch version of `fileglancer` to [PyPI](https://pypi.org/project/fileglancer/), following the Fileglancer [release steps](https://github.com/JaneliaSciComp/fileglancer/blob/main/docs/Release.md).
+
+## 6. Prod Deployment
+
+Announce a deployment in progress in the #fileglancer-support channel on Slack. Then repeat steps 2 and 3 above on the production server.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,20 +52,19 @@ sudo journalctl -u fileglancer -f
 
 ## 4. Run integration tests against the dev deployment
 
-To test the full application stack prior to a production release, ensure `.env` file in this repo contains the following:
+To test the full application stack prior to a production release, ensure the `.env` file in this repo contains the following:
 
 ```
-FGC_ENABLE_TEST_API_KEY=true
-FGC_TEST_API_KEY:'<your-generated-key>'
+FGC_TEST_API_KEY='<your-generated-key>'
 ```
 
-If a FGC_TEST_API_KEY is not already configured, create a new one. Add this key to both the `.env` file for fileglancer-hub and fileglancer-janelia/playwright.
+If a `FGC_TEST_API_KEY` is not already configured, create a new one. 
 
 ```bash
 python -c "import secrets; print(secrets.token_urlsafe(32))"
 ```
 
-The same value for `FGC_TEST_API_KEY` needs to be added to the `.env` file in the repo with your Playwright tests. See the [fileglancer-janelia](https://github.com/JaneliaSciComp/fileglancer-janelia) repo for example Playwright tests and further documentation of this feature.
+Add the generated key as the value for `FCG_TEST_API_KEY` in both the `.env` file for fileglancer-hub and the `.env` file in fileglancer-janelia/playwright. See the [fileglancer-janelia](https://github.com/JaneliaSciComp/fileglancer-janelia) repo for example Playwright tests and further documentation of this feature.
 
 ## 5. Make a new stable release to PyPI
 


### PR DESCRIPTION
Related to clickup id: 86ae17ge1

This PR adds documentation in RELEASE.md on the updated workflow for creating a new Fileglancer release, which includes first creating an alpha version for testing on the fileglancer-dev server, using the Playwright tests added in [PR #2 in fileglancer-janelia](https://github.com/JaneliaSciComp/fileglancer-janelia/pull/2) and enabled via [PR #315 in fileglancer](https://github.com/JaneliaSciComp/fileglancer/pull/315).
@krokicki 